### PR TITLE
Updating example and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ var opts = {
   plugins: [ require('rtc-plugin-node') ]
 };
 
-quickconnect('http://localhost:3000/', opts)
+quickconnect('https://switchboard.rtc.io/', opts)
   .createDataChannel('test')
   .on('channel:opened:test', function(id, dc) {
     console.log('dc opened');
@@ -31,7 +31,7 @@ quickconnect('http://localhost:3000/', opts)
 ```
 
 If you'd like to take it for a spin, then clone this repo, install
-[beefy](https://github.com/chrisdickinson/beefy) (`npm install -g beefy`) and take
+[beefy](https://github.com/chrisdickinson/beefy) and [browserify](browserify.org) (`npm install -g beefy browserify`) and take
 it for a spin:
 
 - run `beefy examples/datachannel.js` in terminal, and open your browser at:

--- a/examples/datachannel.js
+++ b/examples/datachannel.js
@@ -4,8 +4,9 @@ var opts = {
   plugins: [ require('..') ]
 };
 
-quickconnect('http://localhost:3000/', opts)
+quickconnect('https://switchboard.rtc.io/', opts)
   .createDataChannel('test')
   .on('channel:opened:test', function(id, dc) {
     console.log('dc opened');
   });
+

--- a/test/dc-connect.js
+++ b/test/dc-connect.js
@@ -88,7 +88,9 @@ test('close connection 0 and wait for dc close notifications', function(t) {
 
   function handleClose(peerId, datachannel, label) {
     t.equal(label, 'test', 'label == test');
-    t.ok(datachannel.readyState, '2nd arg is a data channel');
+    // changed test from 'readyState' to 'close' 
+    // jtj02 - 13 May 2015
+    t.ok(datachannel.close, '2nd arg is a data channel');
     t.equal(typeof peerId, 'string', '1st args is a string');
 
     closedCount += 1;


### PR DESCRIPTION
Suggest using switchboard.rtc.io for the example. Testing failed for datachannel closing. The member function 'readyState' prompted a node segfault, changed to 'close' and testing works fine.